### PR TITLE
Fix bugs on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
 
     <div class="schedule content-section">
         <h1>Schedule</h1>
-        <em>All times are in CST</em>
+        <center><em>All times are in CST</em></center>
 
         <h2>Friday</h2>
         <ul>

--- a/style.css
+++ b/style.css
@@ -11,7 +11,7 @@ h2,
 h3 {
     margin: auto;
     text-align: center;
-    font-size: 5rem;
+    font-size: 4rem;
 }
 
 h1 {
@@ -106,7 +106,6 @@ a:hover {
     margin: 0.25rem 0;
     color: #fff;
     border-radius: 1rem;
-    height: 2.2rem;
     font-weight: bold;
     font-size: 1.5rem;
     display: flex;


### PR DESCRIPTION
Center "All times are in CST"
Make h1 font size slightly smaller so no horizontal scrolling on small (iPhone 5-ish) devices
Delete fixed size list items so text doesn't overlap on mobile

I also think orange on yellow is a little bit unreadable but I'll leave that to the design team